### PR TITLE
Using standard out for debug loging

### DIFF
--- a/lib/sigsci-agent.sh
+++ b/lib/sigsci-agent.sh
@@ -178,6 +178,9 @@ upstreams = "http://${SIGSCI_UPSTREAM}"
 access-log = "${SIGSCI_REVERSE_PROXY_ACCESSLOG}"
 EOT
 
+    echo "==== Using /dev/stdout for debug logging ===="
+    SIGSCI_LOG_OUT=/dev/stdout
+
     # start agent
     echo "-----> Starting Signal Sciences Agent!"
     (


### PR DESCRIPTION
https://github.com/signalsciences/sigsci/issues/23554

sets stdout or stderr for SIGSCI_LOG_OUT by default