### PR TITLE
Adding optional override for the agent download url

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ To configure the Signal Sciences agent the following environment variables must 
 
 `SIGSCI_SERVER_HOSTNAME` (optional)
 
+`SIGSCI_INTERNAL_AGENT_DOWNLOAD_URL` (optional)
+
 Set environment variables using the `cf` command:
 
 `cf set-env YOUR-APP <variable name> "<value>"`

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ To configure the Signal Sciences agent the following environment variables must 
 
 `SIGSCI_AGENT_DOWNLOAD_URL` (optional, NOTE: This needs to be a fully qualified http(s) path to a tar, gzipped agent file)
 
+**_NOTE: If SIGSCI_AGENT_DOWNLOAD_URL is set, then SIGSCI_AGENT_VERSION will be ignored, and SIGSCI_DISABLE_CHECKSUM_INTEGRITY_CHECK will be implied._**
+
 Set environment variables using the `cf` command:
 
 `cf set-env YOUR-APP <variable name> "<value>"`

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To configure the Signal Sciences agent the following environment variables must 
 
 `SIGSCI_SERVER_HOSTNAME` (optional)
 
-`SIGSCI_INTERNAL_AGENT_DOWNLOAD_URL` (optional)
+`SIGSCI_AGENT_DOWNLOAD_URL` (optional, NOTE: This needs to be a fully qualified http(s) path to a tar, gzipped agent file)
 
 Set environment variables using the `cf` command:
 

--- a/lib/sigsci-agent.sh
+++ b/lib/sigsci-agent.sh
@@ -122,7 +122,8 @@ then
     fi
     else
       # download the build pack from a local repo
-      curl -s --retry 45 --retry-delay 2 -o sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz "${SIGSCI_AGENT_DOWNLOAD_URL}/sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz" > /dev/null
+      echo "-----> Using local SigSci Agent repository ${SIGSCI_AGENT_DOWNLOAD_URL}"
+      curl -s --retry 45 --retry-delay 2 -o sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz $SIGSCI_AGENT_DOWNLOAD_URL > /dev/null
     fi
 
     tar -xzf "sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz"
@@ -244,7 +245,6 @@ EOT
         health_check &
       fi
     fi
-  fi
 
 else
   (>&2 echo "-----> Signal Sciences access keys not set. Agent not starting!!!")

--- a/lib/sigsci-agent.sh
+++ b/lib/sigsci-agent.sh
@@ -87,14 +87,22 @@ then
 
   ## install agent
 
+  # if the customer has set SIGSCI_INTERNAL_AGENT_DOWNLOAD_URL, then use it instead of the dl.signalsciences.net site.
+  if [ -z $SIGSCI_INTERNAL_AGENT_DOWNLOAD_URL ]
+  then
+    DOWNLOAD_URL_BASE='https://dl.signalsciences.net/sigsci-agent'
+  else
+    DOWNLOAD_URL_BASE="${SIGSCI_INTERNAL_AGENT_DOWNLOAD_URL}"
+  fi
+
   # if agent version not specified then get the latest version.
   if [ -z $SIGSCI_AGENT_VERSION ]
   then
-    SIGSCI_AGENT_VERSION=$(curl -s -L --retry 45 --retry-delay 2 https://dl.signalsciences.net/sigsci-agent/VERSION)
+    SIGSCI_AGENT_VERSION=$(curl -s -L --retry 45 --retry-delay 2 "${DOWNLOAD_URL_BASE}/VERSION")
   fi
 
   # check if version exists.
-  STATUS=$(curl -s --retry 45 --retry-delay 2 -o /dev/null -w "%{http_code}" https://dl.signalsciences.net/sigsci-agent/${SIGSCI_AGENT_VERSION}/VERSION)
+  STATUS=$(curl -s --retry 45 --retry-delay 2 -o /dev/null -w "%{http_code}" "${DOWNLOAD_URL_BASE}/${SIGSCI_AGENT_VERSION}/VERSION")
   if [ $STATUS -ne 200 ]
   then
 
@@ -104,11 +112,11 @@ then
 
   else
     echo "-----> Downloading sigsci-agent"
-    curl -s --retry 45 --retry-delay 2 -o sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz https://dl.signalsciences.net/sigsci-agent/${SIGSCI_AGENT_VERSION}/linux/sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz > /dev/null
+    curl -s --retry 45 --retry-delay 2 -o sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz "${DOWNLOAD_URL_BASE}/${SIGSCI_AGENT_VERSION}/linux/sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz" > /dev/null
 
     if [ -z $SIGSCI_DISABLE_CHECKSUM_INTEGRITY_CHECK ]
     then
-        curl -s --retry 45 --retry-delay 2 -o sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz.sha256 https://dl.signalsciences.net/sigsci-agent/${SIGSCI_AGENT_VERSION}/linux/sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz.sha256 > /dev/null
+        curl -s --retry 45 --retry-delay 2 -o sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz.sha256 "${DOWNLOAD_URL_BASE}/${SIGSCI_AGENT_VERSION}/linux/sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz.sha256" > /dev/null
 
         # validate the gzip file
         if [[ "$(shasum -c sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz.sha256)" != *"OK"* ]]

--- a/lib/sigsci-agent.sh
+++ b/lib/sigsci-agent.sh
@@ -87,7 +87,7 @@ then
 
   ## install agent
 
-  #  if we're downloading from an internal repo, then we don't need to worry about figuring out what version we need
+  # if a specific download url is provided, we can bypass version-determination logic
   if [ -z $SIGSCI_AGENT_DOWNLOAD_URL ]
   then
     # if agent version not specified then get the latest version.
@@ -117,16 +117,19 @@ then
         then
             (>&2 echo "-----> sigsci-agent not installed because checksum integrity check failed")
             exit 1
+        else
+          # shasum expects to find the agent tar.gz file with the version in the name. Rename the file if shasum check passes so that the name is consistent regardless of where the file was downloaded from
+          mv sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz sigsci-agent.tar.gz
         fi
       fi
     fi
     else
-      # download the build pack from a local repo
-      echo "-----> Using local SigSci Agent repository ${SIGSCI_AGENT_DOWNLOAD_URL}"
-      curl -s --retry 45 --retry-delay 2 -o sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz $SIGSCI_AGENT_DOWNLOAD_URL > /dev/null
+      # download the agent tar.gz from a custom url
+      echo "-----> Downloading SigSci Agent from ${SIGSCI_AGENT_DOWNLOAD_URL}"
+      curl -s --retry 45 --retry-delay 2 -o sigsci-agent.tar.gz $SIGSCI_AGENT_DOWNLOAD_URL > /dev/null
     fi
 
-    tar -xzf "sigsci-agent_${SIGSCI_AGENT_VERSION}.tar.gz"
+    tar -xzf "sigsci-agent.tar.gz"
     mv sigsci-agent "${SIGSCI_DIR}/bin/sigsci-agent"
     echo "-----> Finished installing sigsci-agent"
 

--- a/lib/sigsci-agent.sh
+++ b/lib/sigsci-agent.sh
@@ -87,14 +87,6 @@ then
 
   ## install agent
 
-  # if the customer has set SIGSCI_INTERNAL_AGENT_DOWNLOAD_URL, then use it instead of the dl.signalsciences.net site.
-  if [ -z $SIGSCI_INTERNAL_AGENT_DOWNLOAD_URL ]
-  then
-    DOWNLOAD_URL_BASE='https://dl.signalsciences.net/sigsci-agent'
-  else
-    DOWNLOAD_URL_BASE="${SIGSCI_INTERNAL_AGENT_DOWNLOAD_URL}"
-  fi
-
   # if agent version not specified then get the latest version.
   if [ -z $SIGSCI_AGENT_VERSION ]
   then


### PR DESCRIPTION
This change checks for the SIGSCI_INTERNAL_AGENT_DOWNLOAD_URL variable.  If it isn't set, use the default dl.signalsciences.net.

NOTE: I'll be updating the powershell script next. We just needed to get this out asap.